### PR TITLE
Fix compatibility for nested modules

### DIFF
--- a/build_doc.sh
+++ b/build_doc.sh
@@ -11,7 +11,7 @@ fi
 # Build docs
 git clone https://github.com/ktorio/ktor/ ktor
 cd ktor
-./gradlew dokkaHtmlMultiModule -PreleaseVersion=${KTOR_VERSION} --no-parallel
+./gradlew :dokkaHtmlMultiModule -PreleaseVersion=${KTOR_VERSION} --no-parallel
 cd ..
 rm -rf docs
 cp -R ./versions/${KTOR_VERSION} ./docs


### PR DESCRIPTION
## Background

Ktor has many nested modules, which leads to the existence of multiple Gradle parent projects. By default, the `dokkaHtmlMultiModule` task is created for **all** parent projects. 

So if there are nested modules and `dokkaHtmlMultiModule` is run, it means it will be executed for all parent projects, not just the root one, which in Gradle 8 leads to errors like the following:

> Reason: Task ':dokkaHtmlMultiModule' uses this output of task ':sqldelight-compiler:dokkaHtmlMultiModule' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. 

This error could be observed after https://github.com/ktorio/ktor/pull/3743 is merged.

For more details, see https://github.com/Kotlin/dokka/issues/2954

## Solution

Only run `dokkaHtmlMultiModule` for the root project by adding a semicolon in front of it. This way, it will not be called on any projects other than the root one, and so it will not lead to task dependency errors.