### PR TITLE
Release Script: Remove obsolete command

### DIFF
--- a/build_doc.sh
+++ b/build_doc.sh
@@ -16,7 +16,6 @@ cd ..
 rm -rf docs
 cp -R ./versions/${KTOR_VERSION} ./docs
 echo api.ktor.io > ./docs/CNAME
-cp -R ./old/ ./docs/old
 rm -rf ktor
 
 # Add Google Tag Manager script to the files


### PR DESCRIPTION
There's no directory such as "old" in Dokka's output. So, the command fails during the build, and the following commands do not execute.