### PR TITLE
KTOR-8892 Get old versions from current docs

### DIFF
--- a/build_doc.sh
+++ b/build_doc.sh
@@ -8,16 +8,47 @@ if [ -z "${KTOR_VERSION}" ]; then
   exit 1
 fi
 
-# Build docs
-versionsDir=$(realpath "./versions/")
-git clone https://github.com/ktorio/ktor/ ktor
+currentVersion=$(cat docs/version.json | jq -r ".version")
+echo "Current docs version is: $currentVersion"
+
+if [ $KTOR_VERSION == $currentVersion ]; then
+  echo "Skipping. The requested version is the same."
+  exit 0
+fi
+
+# Make old versions visible for Dokka
+versionsDir="./versions/"
+if [ -d $versionsDir ]; then
+  echo "Versions directory already exists. Skipping old versions copying."
+else
+  echo "Copying old versions..."
+  mkdir "$versionsDir"
+  cp -R docs ${versionsDir}/${currentVersion}
+  mv ${versionsDir}/${currentVersion}/older/* ${versionsDir}
+  echo "Done."
+fi
+
+versionsDir=$(realpath "$versionsDir")
+echo \n"Old versions:"
+find "$versionsDir" -maxdepth 1 -type d -exec basename {} \; | tail -n +2 | sort --reverse
+
+# Try to clone the Ktor repository at the specific version. Use the main branch if failed.
+echo \n"Cloning the Ktor repository..."
+git clone --quiet --depth 1 --branch "$KTOR_VERSION" https://github.com/ktorio/ktor/ ktor ||
+  git clone --quiet --depth 1 https://github.com/ktorio/ktor/ ktor
+
+# Generate new API docs
 cd ktor
-./gradlew :ktor-dokka:dokkaGenerate -PreleaseVersion=${KTOR_VERSION} -Pktor.dokka.versionsDirectory="$versionsDir" --no-parallel
+./gradlew --quiet :ktor-dokka:dokkaGenerate -PreleaseVersion=${KTOR_VERSION} -Pktor.dokka.versionsDirectory="$versionsDir"
 cd ..
+
+# Update docs
 rm -rf docs
-cp -R ./versions/${KTOR_VERSION} ./docs
+cp -R ${versionsDir}/${KTOR_VERSION} ./docs
 echo api.ktor.io > ./docs/CNAME
-rm -rf ktor
 
 # Add Google Tag Manager script to the files
 ./inject_gtm_script.sh docs
+
+## Cleanup
+rm -rf ktor versions


### PR DESCRIPTION
[KTOR-8892](https://youtrack.jetbrains.com/issue/KTOR-8892) Fix api.ktor.io publishing

In order to reduce number of files in the repository I've changed the script to use versions stored in `docs/older` instead of storing `versions` in the repository.

With these changes we will be able to remove the `versions/` directory from the repository.